### PR TITLE
[Temporarily] Removed support for Proxies on ApiClient

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,6 @@
     "fs": false
   },
   "dependencies": {
-    "superagent": "3.8.3",
-    "superagent-proxy": "^3.0.0",
     "app-root-path": "^2.1.0",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
@@ -21,6 +19,7 @@
     "memory-cache": "^0.2.0",
     "node-forge": ">=1.0.0",
     "promise": "^8.0.1",
+    "superagent": "3.8.3",
     "winston": "^3.3.3",
     "winston-daily-rotate-file": "^4.5.1"
   },

--- a/src/ApiClient.js
+++ b/src/ApiClient.js
@@ -16,18 +16,18 @@
 (function(root, factory) {
   if (typeof define === 'function' && define.amd) {
     // AMD. Register as an anonymous module.
-    define(['superagent', 'superagent-proxy', 'querystring', 'Authentication/MerchantConfig', 'Authentication/Logger', 'Authentication/Constants', 'Authentication/Authorization', 'Authentication/PayloadDigest'], factory);
+    define(['superagent', 'querystring', 'Authentication/MerchantConfig', 'Authentication/Logger', 'Authentication/Constants', 'Authentication/Authorization', 'Authentication/PayloadDigest'], factory);
   } else if (typeof module === 'object' && module.exports) {
     // CommonJS-like environments that support module.exports, like Node.
-    module.exports = factory(require('superagent'), require('superagent-proxy'), require('querystring'), require('./authentication/core/MerchantConfig'), require('./authentication/logging/Logger'), require('./authentication/util/Constants'), require('./authentication/core/Authorization'), require('./authentication/payloadDigest/DigestGenerator'));
+    module.exports = factory(require('superagent'), require('querystring'), require('./authentication/core/MerchantConfig'), require('./authentication/logging/Logger'), require('./authentication/util/Constants'), require('./authentication/core/Authorization'), require('./authentication/payloadDigest/DigestGenerator'));
   } else {
     // Browser globals (root is window)
     if (!root.CyberSource) {
       root.CyberSource = {};
     }
-    root.CyberSource.ApiClient = factory(root.superagent, root.superagent_proxy, root.querystring, root.Authentication.MerchantConfig, root.Authentication.Logger, root.Authentication.Constants, root.Authentication.Authorization, root.Authentication.PayloadDigest);
+    root.CyberSource.ApiClient = factory(root.superagent, root.querystring, root.Authentication.MerchantConfig, root.Authentication.Logger, root.Authentication.Constants, root.Authentication.Authorization, root.Authentication.PayloadDigest);
   }
-}(this, function(superagent, superagent_proxy, querystring, MerchantConfig, Logger, Constants, Authorization, PayloadDigest) {
+}(this, function(superagent, querystring, MerchantConfig, Logger, Constants, Authorization, PayloadDigest) {
   'use strict';
 
   /**
@@ -480,24 +480,12 @@
     var _this = this;
     var url = this.buildUrl(path, pathParams);
     var useProxy = this.merchantConfig.getUseProxy();
-    var proxyAddress = this.merchantConfig.getProxyAddress();
-    var proxyPort = this.merchantConfig.getProxyPort();
-    var proxyUser = this.merchantConfig.getProxyUser();
-    var proxyPassword = this.merchantConfig.getProxyPassword();
     var enableClientCert = this.merchantConfig.getEnableClientCert();
 
     var request = superagent(httpMethod, url);
 
-    if (useProxy && (proxyAddress != null && proxyAddress != '')) {
-      require('superagent-proxy')(require('superagent'));
-      var request = superagent(httpMethod, url);
-      if ((proxyUser != null && proxyUser != '') && (proxyPassword!= null && proxyPassword != '')) {
-        var proxy  = process.env.http_proxy || 'http://' + proxyUser + ':' + proxyPassword + '@' + proxyAddress + ':' + proxyPort; 
-      }
-      else {
-        var proxy  = process.env.http_proxy || 'http://' +  proxyAddress + ':' + proxyPort;
-      }
-      request.proxy(proxy); 
+    if (useProxy) {
+      return callback(new Error(Constants.PROXY_SUPPORT_TEMPORARY_DISABLED))
     }
 
     var fslib = require('fs');

--- a/src/authentication/util/Constants.js
+++ b/src/authentication/util/Constants.js
@@ -79,6 +79,7 @@ module.exports = {
     CLIENT_SECRET_EMPTY               :  "Client Secret is Empty/Null",
     ACCESS_TOKEN_EMPTY                :  "AccessToken is Empty/Null",
     REFRESH_TOKEN_EMPTY               :  "RefreshToken is Empty/Null",
+    PROXY_SUPPORT_TEMPORARY_DISABLED  :  "Proxy support has been temporarily disabled, please wait for the newest release of `superagent-proxy` which includes `proxy-agent@6.3.0`",
     /*Fall back default values*/
 
     DEFAULT_LOG_SIZE                  :  "10485760", //10 MB


### PR DESCRIPTION
Description
---

This library has now a **critical security flaw** in a deep dependency called `vm2`. You can see the chain below:

- `superagent-proxy -> proxy-agent -> pac-proxy-agent -> pac-resolver -> degenerator`

Fortunately for us `proxy-agent` has been updated to not use `vm2` anymore but it hasn't been integrated yet to `superagent-proxy` although there is a PR open [here](https://github.com/TooTallNate/superagent-proxy/pull/47)

The Cybersource SDK uses the `superagent-proxy` dependency to offer a way to support networks underproxies, so getting rid of that functionality will probably not be desirable for the Cybersource team.

Our recomendation is therefore, to wait for the `superagent-proxy` library to get upgraded and either raise a PR against the Cybersource SDK or talk to the CyberSource account managers to get it done for us. In the meantime, we can remove the support for proxies.

Screenshots

- Client using the SDK with `useProxy` set to `true`:

<img width="825" alt="image" src="https://github.com/cwilgenhoff/cybersource-rest-client-node/assets/1410978/8f92e847-baf2-46d7-bffb-3d25337e68eb">

- Client using the SDK with `useProxy` set to `false` or unset, and a capture token can be created with the SDK:

<img width="324" alt="image" src="https://github.com/cwilgenhoff/cybersource-rest-client-node/assets/1410978/cd194e18-ca62-4c5d-b15a-c3bd6cd2e261">
